### PR TITLE
Refactor `BatchSequence` by unifying `slice` and `generate_index_interval` into a single `filter` method.

### DIFF
--- a/common/extended_int.py
+++ b/common/extended_int.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+from typing import Literal, Any, SupportsInt
+from functools import total_ordering
+
+
+@total_ordering
+class ExtendedInt:
+    """
+    Represents an integer that can also be positive or negative infinity.
+
+    .. note::
+       This class only implements the minimum behaviors needed in our application.
+       It can be enhanced in the future to support more operations or use cases.
+    """
+
+    def __init__(self, value: int | Literal["inf", "-inf"]) -> None:
+        self._value = value
+
+    @classmethod
+    def from_optional_int(
+        self, value: int | None, none_as: Literal["inf", "-inf"]
+    ) -> ExtendedInt:
+        return ExtendedInt(value if value is not None else none_as)
+
+    def __int__(self) -> int:
+        if not isinstance(self._value, int):
+            raise ValueError(f"Cannot convert {self._value} to simple integer.")
+
+        return self._value
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, ExtendedInt):
+            return NotImplemented
+
+        if self._value == other._value:
+            return False
+
+        if isinstance(self._value, int) and isinstance(other._value, int):
+            return self._value < other._value
+
+        if self._value == "inf" or other._value == "-inf":
+            return False
+
+        return True
+
+    def __eq__(self, other: Any) -> bool:
+        match other:
+            case ExtendedInt():
+                return self._value == other._value
+            case SupportsInt():
+                return self._value == int(other)
+            case "inf" | "-inf":
+                return self._value == other
+            case _:
+                return NotImplemented
+
+    def __add__(self, value: int) -> ExtendedInt:
+        match self._value:
+            case int():
+                return ExtendedInt(self._value + value)
+            case _:
+                return ExtendedInt(self._value)
+
+    def __sub__(self, value: int) -> ExtendedInt:
+        return self + (-value)
+
+    def __repr__(self) -> str:
+        return repr(self._value)
+
+    def __str__(self) -> str:
+        return str(self._value)
+
+    def to_optional_int(self) -> int | None:
+        return self._value if isinstance(self._value, int) else None

--- a/common/state.py
+++ b/common/state.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Literal, cast
+from typing import Literal
 from collections.abc import Sequence
 
 
@@ -12,12 +12,3 @@ STATES: Sequence[State] = ("initialized", *OPERATIONAL_STATES)
 
 def is_state_before_or_equal(base_state: State, comparison_state: State) -> bool:
     return STATES.index(base_state) <= STATES.index(comparison_state)
-
-
-def next_state_or_none(state: State) -> OperationalState | None:
-    state_index = STATES.index(state)
-    return (
-        None
-        if state_index + 1 >= len(STATES)
-        else cast(OperationalState, STATES[state_index])
-    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ requests==2.32.3
 pydantic==2.9.2
 pydantic-settings==2.7.1
 tenacity==9.0.0
-portion==2.6.0


### PR DESCRIPTION
In this PR, `BatchSequence.slice` and `BatchSequence.generate_index_interval` are merged, as they are mostly used together and are now exposed through a simple `filter` method. This allows for single-call behaviors in the `BatchSequence` class, simplifying the code and helping to fix race conditions.