### PR TITLE
Fix/sync node with sequencer

### DIFF
--- a/common/db.py
+++ b/common/db.py
@@ -294,7 +294,7 @@ class InMemoryDB:
                 "state": "initialized",
             }
         else:
-            return self._get_operational_batch_record_by_hash_or_empty(
+            return self.get_operational_batch_record_by_hash_or_empty(
                 app_name, batch_hash
             )
 
@@ -426,7 +426,7 @@ class InMemoryDB:
             )
             return
 
-        target_batch = self._get_operational_batch_record_by_hash_or_empty(
+        target_batch = self.get_operational_batch_record_by_hash_or_empty(
             app_name, signature_data["hash"]
         ).get("batch", {})
         target_batch["lock_signature"] = signature_data["signature"]
@@ -466,7 +466,7 @@ class InMemoryDB:
             if index % zconfig.SNAPSHOT_CHUNK == 0:
                 snapshot_indexes.append(index)
 
-        target_batch = self._get_operational_batch_record_by_hash_or_empty(
+        target_batch = self.get_operational_batch_record_by_hash_or_empty(
             app_name, signature_data["hash"]
         ).get("batch", {})
         target_batch["finalization_signature"] = signature_data["signature"]
@@ -716,7 +716,7 @@ class InMemoryDB:
             target_batch_sequence.append(batch)
             target_batches_hash_set.add(batch["hash"])
 
-    def _get_operational_batch_record_by_hash_or_empty(
+    def get_operational_batch_record_by_hash_or_empty(
         self, app_name: str, batch_hash: str
     ) -> BatchRecord:
         return self.apps[app_name]["operational_batch_sequence"].get_or_empty(

--- a/node/tasks.py
+++ b/node/tasks.py
@@ -55,7 +55,7 @@ def send_batches() -> None:
 def send_app_batches_iteration(app_name):
     response = send_app_batches(app_name).get("data", {})
     sequencer_last_finalized_hash = response.get("finalized", {}).get("hash", "")
-    finish_condition = not sequencer_last_finalized_hash or zdb.get_batch_record_by_hash_or_empty(app_name,
+    finish_condition = not sequencer_last_finalized_hash or zdb.get_operational_batch_record_by_hash_or_empty(app_name,
                                                                                                   sequencer_last_finalized_hash)
     return finish_condition
 


### PR DESCRIPTION
- The node should find sequencer last finalized hash among operational batches instead of init batches in order of detecting it has been sync with sequencer