### PR TITLE
Fix: Remove is_synced decorator condition from switch end-point

### DIFF
--- a/node/routes.py
+++ b/node/routes.py
@@ -99,7 +99,6 @@ def post_dispute() -> Response:
 
 @node_blueprint.route("/switch", methods=["POST"])
 @utils.validate_version
-@utils.is_synced
 @utils.validate_body_keys(required_keys=["timestamp", "proofs"])
 def post_switch_sequencer() -> Response:
     """Switch the sequencer based on the provided proofs."""


### PR DESCRIPTION
Nodes should contribute switch even when they are not synced and work with new sequencer in syncing process and after that if the network decides to switch the sequencer.
