### PR TITLE
Fix/ bugs in out of reach simulation and switch process 

### DIFF
--- a/node/routes.py
+++ b/node/routes.py
@@ -114,6 +114,7 @@ def post_switch_sequencer() -> Response:
     def run_switch_sequencer():
         tasks.switch_sequencer(old_sequencer_id, new_sequencer_id)
 
+    zlogger.info(f"switch request received {zconfig.NODES[old_sequencer_id]['socket']} -> {zconfig.NODES[new_sequencer_id]['socket']}.")
     threading.Thread(target=run_switch_sequencer).start()
 
     return success_response(data={})

--- a/node/tasks.py
+++ b/node/tasks.py
@@ -380,9 +380,6 @@ async def send_dispute_request(
 
 async def send_switch_request(session, node, proofs):
     """Send a single switch request to a node."""
-    if node["id"] == zconfig.NODE["id"]:
-        return
-
     data = json.dumps({
         "proofs": proofs,
         "timestamp": int(time.time()),
@@ -402,7 +399,7 @@ async def send_switch_requests(proofs: list[dict[str, Any]]) -> None:
     async with aiohttp.ClientSession() as session:
         tasks = [
             send_switch_request(session, node, proofs)
-            for node in zconfig.NODES.values()
+            for node in zconfig.NODES.values() if node["id"] != zconfig.NODE["id"]
         ]
         await asyncio.gather(*tasks)
 

--- a/sequencer_sabotage_simulation/state.py
+++ b/sequencer_sabotage_simulation/state.py
@@ -5,11 +5,19 @@ import time
 
 
 class SequencerSabotageSimulationState:
+    _instance = None
 
     def __init__(self, conf: SequencerSabotageSimulation):
         self._conf = conf
         self._out_of_reach = False
         self._stop_event = threading.Event()  # To allow stopping the thread gracefully
+
+    @staticmethod
+    def get_instance(conf: SequencerSabotageSimulation):
+        if not SequencerSabotageSimulationState._instance:
+            SequencerSabotageSimulationState._instance = SequencerSabotageSimulationState(conf=conf)
+        SequencerSabotageSimulationState._instance.start_simulating()
+        return SequencerSabotageSimulationState._instance
 
     def _simulate_out_of_reach(self):
         """Daemon thread function to periodically check the condition."""
@@ -39,4 +47,4 @@ class SequencerSabotageSimulationState:
         return self._out_of_reach
 
 
-sequencer_sabotage_simulation_state = SequencerSabotageSimulationState(conf=SequencerSabotageSimulation())
+sequencer_sabotage_simulation_state = SequencerSabotageSimulationState.get_instance(conf=SequencerSabotageSimulation())


### PR DESCRIPTION
- Fixes a bug in out-of-reach sequencer simulation that resulted in all nodes starting to get out of reach together and returning back together to a process that the out-of-reach period starts on the sequencer just after it received the sequencer role
- Send switch request to nodes in async way to make the process faster
- Send switch requests to other nodes before starting the switch process on the disputor node itself to ensure other nodes will not start the switch process with a delay that the switch process has