### PR TITLE
Fix/make find highest finalized batch concurrent

### DIFF
--- a/node/node_queries_task.py
+++ b/node/node_queries_task.py
@@ -1,17 +1,19 @@
 import asyncio
-from typing import Any, Dict
+from typing import Any
+
 import aiohttp
+
 from common.batch import stateful_batch_to_batch_record
+from common.db import zdb
 from common.logger import zlogger
 from config import zconfig
-from common.db import zdb
 
 
 async def fetch_node_last_finalized_batch_record_or_empty(
         session: aiohttp.ClientSession,
-        node: Dict[str, Any],
+        node: dict[str, Any],
         app_name: str
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Fetch last finalized batch from a single node asynchronously."""
     url = f'{node["socket"]}/node/{app_name}/batches/finalized/last'
     try:
@@ -33,7 +35,7 @@ async def fetch_node_last_finalized_batch_record_or_empty(
         return {}
 
 
-async def _find_all_nodes_last_finalized_batch_record_core(app_name: str) -> Dict[str, Any]:
+async def _find_all_nodes_last_finalized_batch_record_core(app_name: str) -> dict[str, Any]:
     """Core async implementation to find all nodes last finalized batch record."""
     try:
         # Get local record first
@@ -80,7 +82,7 @@ async def _find_all_nodes_last_finalized_batch_record_core(app_name: str) -> Dic
         )
 
 
-def find_all_nodes_last_finalized_batch_record(app_name: str) -> Dict[str, Any]:
+def find_all_nodes_last_finalized_batch_record(app_name: str) -> dict[str, Any]:
     """
     Synchronous wrapper to find the last finalized batch record.
     For async contexts, use find_all_nodes_last_finalized_batch_record_async instead.
@@ -96,7 +98,7 @@ def find_all_nodes_last_finalized_batch_record(app_name: str) -> Dict[str, Any]:
         )
 
 
-async def find_all_nodes_last_finalized_batch_record_async(app_name: str) -> Dict[str, Any]:
+async def find_all_nodes_last_finalized_batch_record_async(app_name: str) -> dict[str, Any]:
     """
     Async wrapper to find the last finalized batch record of network.
     Can be called from async contexts.

--- a/node/node_queries_task.py
+++ b/node/node_queries_task.py
@@ -10,7 +10,7 @@ from common.logger import zlogger
 from config import zconfig
 
 
-async def fetch_node_last_finalized_batch_record_or_empty(
+async def _fetch_node_last_finalized_batch_record_or_empty(
         session: aiohttp.ClientSession,
         node: dict[str, Any],
         app_name: str
@@ -58,7 +58,7 @@ async def _find_all_nodes_last_finalized_batch_record_core(app_name: str) -> dic
         # Query all nodes concurrently
         async with aiohttp.ClientSession() as session:
             tasks = [
-                fetch_node_last_finalized_batch_record_or_empty(session, node, app_name)
+                _fetch_node_last_finalized_batch_record_or_empty(session, node, app_name)
                 for node in nodes_to_query
             ]
             results = await asyncio.gather(*tasks)

--- a/node/node_queries_task.py
+++ b/node/node_queries_task.py
@@ -3,27 +3,11 @@ from typing import Any
 
 import aiohttp
 
+from common.batch import BatchRecord
 from common.batch import stateful_batch_to_batch_record
 from common.db import zdb
-from common.batch import BatchRecord
 from common.logger import zlogger
 from config import zconfig
-
-
-def find_all_nodes_last_finalized_batch_record(app_name: str) -> BatchRecord:
-    """
-    Synchronous wrapper to find the last finalized batch record.
-    For async contexts, use find_all_nodes_last_finalized_batch_record_async instead.
-    """
-    try:
-        return asyncio.run(_find_all_nodes_last_finalized_batch_record_core(app_name))
-    except Exception as e:
-        zlogger.error(f"Critical error in find_all_nodes_last_finalized_batch_record: {str(e)}")
-        # Return local record as ultimate fallback
-        return zdb.get_last_operational_batch_record_or_empty(
-            app_name=app_name,
-            state="finalized"
-        )
 
 
 async def find_all_nodes_last_finalized_batch_record_async(app_name: str) -> BatchRecord:

--- a/node/node_queries_task.py
+++ b/node/node_queries_task.py
@@ -5,6 +5,7 @@ import aiohttp
 
 from common.batch import stateful_batch_to_batch_record
 from common.db import zdb
+from common.batch import BatchRecord
 from common.logger import zlogger
 from config import zconfig
 
@@ -13,7 +14,7 @@ async def fetch_node_last_finalized_batch_record_or_empty(
         session: aiohttp.ClientSession,
         node: dict[str, Any],
         app_name: str
-) -> dict[str, Any]:
+) -> BatchRecord:
     """Fetch last finalized batch from a single node asynchronously."""
     url = f'{node["socket"]}/node/{app_name}/batches/finalized/last'
     try:

--- a/node/node_queries_task.py
+++ b/node/node_queries_task.py
@@ -10,6 +10,39 @@ from common.logger import zlogger
 from config import zconfig
 
 
+def find_all_nodes_last_finalized_batch_record(app_name: str) -> dict[str, Any]:
+    """
+    Synchronous wrapper to find the last finalized batch record.
+    For async contexts, use find_all_nodes_last_finalized_batch_record_async instead.
+    """
+    try:
+        return asyncio.run(_find_all_nodes_last_finalized_batch_record_core(app_name))
+    except Exception as e:
+        zlogger.error(f"Critical error in find_all_nodes_last_finalized_batch_record: {str(e)}")
+        # Return local record as ultimate fallback
+        return zdb.get_last_operational_batch_record_or_empty(
+            app_name=app_name,
+            state="finalized"
+        )
+
+
+async def find_all_nodes_last_finalized_batch_record_async(app_name: str) -> dict[str, Any]:
+    """
+    Async wrapper to find the last finalized batch record of network.
+    Can be called from async contexts.
+    """
+    try:
+        # Get the result asynchronously
+        return await _find_all_nodes_last_finalized_batch_record_core(app_name)
+    except Exception as e:
+        zlogger.error(f"Critical error in find_all_nodes_last_finalized_batch_record: {str(e)}")
+        # Return local record as ultimate fallback
+        return zdb.get_last_operational_batch_record_or_empty(
+            app_name=app_name,
+            state="finalized"
+        )
+
+
 async def _fetch_node_last_finalized_batch_record_or_empty(
         session: aiohttp.ClientSession,
         node: dict[str, Any],
@@ -77,39 +110,6 @@ async def _find_all_nodes_last_finalized_batch_record_core(app_name: str) -> dic
     except Exception as e:
         zlogger.error(f"Error in find_all_nodes_last_finalized_batch_record: {str(e)}")
         # Return local record as fallback
-        return zdb.get_last_operational_batch_record_or_empty(
-            app_name=app_name,
-            state="finalized"
-        )
-
-
-def find_all_nodes_last_finalized_batch_record(app_name: str) -> dict[str, Any]:
-    """
-    Synchronous wrapper to find the last finalized batch record.
-    For async contexts, use find_all_nodes_last_finalized_batch_record_async instead.
-    """
-    try:
-        return asyncio.run(_find_all_nodes_last_finalized_batch_record_core(app_name))
-    except Exception as e:
-        zlogger.error(f"Critical error in find_all_nodes_last_finalized_batch_record: {str(e)}")
-        # Return local record as ultimate fallback
-        return zdb.get_last_operational_batch_record_or_empty(
-            app_name=app_name,
-            state="finalized"
-        )
-
-
-async def find_all_nodes_last_finalized_batch_record_async(app_name: str) -> dict[str, Any]:
-    """
-    Async wrapper to find the last finalized batch record of network.
-    Can be called from async contexts.
-    """
-    try:
-        # Get the result asynchronously
-        return await _find_all_nodes_last_finalized_batch_record_core(app_name)
-    except Exception as e:
-        zlogger.error(f"Critical error in find_all_nodes_last_finalized_batch_record: {str(e)}")
-        # Return local record as ultimate fallback
         return zdb.get_last_operational_batch_record_or_empty(
             app_name=app_name,
             state="finalized"

--- a/node/node_queries_task.py
+++ b/node/node_queries_task.py
@@ -33,7 +33,7 @@ async def fetch_node_last_finalized_batch(
         return {}
 
 
-async def _find_highest_finalized_batch_record_core(app_name: str) -> Dict[str, Any]:
+async def _find_all_nodes_last_finalized_batch_record_core(app_name: str) -> Dict[str, Any]:
     """Core async implementation to find highest finalized batch record."""
     try:
         # Get local record first
@@ -80,7 +80,7 @@ async def _find_highest_finalized_batch_record_core(app_name: str) -> Dict[str, 
         )
 
 
-def find_highest_finalized_batch_record(app_name: str) -> Dict[str, Any]:
+def find_all_nodes_last_finalized_batch_record(app_name: str) -> Dict[str, Any]:
     """
     Thread-safe wrapper to find the highest finalized batch record.
     Can be called from both sync and async contexts.
@@ -92,10 +92,10 @@ def find_highest_finalized_batch_record(app_name: str) -> Dict[str, Any]:
             # We're in an async context, use await directly
             if loop.is_running():
                 raise RuntimeError("Cannot run the event loop while another loop is running")
-            return loop.run_until_complete(_find_highest_finalized_batch_record_core(app_name))
+            return loop.run_until_complete(_find_all_nodes_last_finalized_batch_record_core(app_name))
         except RuntimeError:
             # We're in a sync context, create a new loop
-            return asyncio.run(_find_highest_finalized_batch_record_core(app_name))
+            return asyncio.run(_find_all_nodes_last_finalized_batch_record_core(app_name))
     except Exception as e:
         zlogger.error(f"Critical error in find_highest_finalized_batch_record: {str(e)}")
         # Return local record as ultimate fallback
@@ -105,15 +105,14 @@ def find_highest_finalized_batch_record(app_name: str) -> Dict[str, Any]:
         )
 
 
-# Modify find_highest_finalized_batch_record to be async
-async def find_highest_finalized_batch_record_async(app_name: str) -> Dict[str, Any]:
+async def find_all_nodes_last_finalized_batch_record_async(app_name: str) -> Dict[str, Any]:
     """
     Async wrapper to find the highest finalized batch record.
     Can be called from async contexts.
     """
     try:
         # Get the result asynchronously
-        return await _find_highest_finalized_batch_record_core(app_name)
+        return await _find_all_nodes_last_finalized_batch_record_core(app_name)
     except Exception as e:
         zlogger.error(f"Critical error in find_highest_finalized_batch_record: {str(e)}")
         # Return local record as ultimate fallback

--- a/node/node_queries_task.py
+++ b/node/node_queries_task.py
@@ -82,20 +82,11 @@ async def _find_all_nodes_last_finalized_batch_record_core(app_name: str) -> Dic
 
 def find_all_nodes_last_finalized_batch_record(app_name: str) -> Dict[str, Any]:
     """
-    Thread-safe wrapper to find the highest finalized batch record.
-    Can be called from both sync and async contexts.
+    Synchronous wrapper to find the highest finalized batch record.
+    For async contexts, use find_all_nodes_last_finalized_batch_record_async instead.
     """
     try:
-        # Check if we're in an async context
-        try:
-            loop = asyncio.get_event_loop()
-            # We're in an async context, use await directly
-            if loop.is_running():
-                raise RuntimeError("Cannot run the event loop while another loop is running")
-            return loop.run_until_complete(_find_all_nodes_last_finalized_batch_record_core(app_name))
-        except RuntimeError:
-            # We're in a sync context, create a new loop
-            return asyncio.run(_find_all_nodes_last_finalized_batch_record_core(app_name))
+        return asyncio.run(_find_all_nodes_last_finalized_batch_record_core(app_name))
     except Exception as e:
         zlogger.error(f"Critical error in find_highest_finalized_batch_record: {str(e)}")
         # Return local record as ultimate fallback

--- a/node/node_queries_task.py
+++ b/node/node_queries_task.py
@@ -1,0 +1,78 @@
+import asyncio
+from typing import Any, Dict
+
+import aiohttp
+
+from common.batch import stateful_batch_to_batch_record
+from common.db import zdb
+from common.logger import zlogger
+from config import zconfig
+
+
+async def fetch_node_batch(
+        session: aiohttp.ClientSession,
+        node: Dict[str, Any],
+        app_name: str,
+        retries: int = 3
+) -> Dict[str, Any]:
+    """Fetch last finalized batch from a single node with retry logic."""
+    if node["id"] == zconfig.NODE["id"]:
+        return {}
+
+    url = f'{node["socket"]}/node/{app_name}/batches/finalized/last'
+
+    async def attempt_request():
+        try:
+            async with session.get(url, headers=zconfig.HEADERS) as response:
+                data = await response.json()
+                if data.get("status") == "error":
+                    return {}
+                return stateful_batch_to_batch_record(data["data"])
+        except Exception as e:
+            raise e
+
+    for attempt in range(retries):
+        try:
+            return await attempt_request()
+        except Exception as e:
+            if attempt == retries - 1:
+                zlogger.error(
+                    f"Failed to query node {node['id']} for last finalized batch "
+                    f"at {url} after {retries} attempts: {str(e)}"
+                )
+                return {}
+            await asyncio.sleep(1)  # Delay before retry
+
+
+async def async_find_highest_finalized_batch_record(app_name: str) -> Dict[str, Any]:
+    """Find the last finalized batch record from all nodes concurrently."""
+    # Get local record first
+    last_finalized_batch_record = zdb.get_last_operational_batch_record_or_empty(
+        app_name=app_name, state="finalized"
+    )
+
+    # Set up client session with timeout
+    timeout = aiohttp.ClientTimeout(total=10)  # 10 second total timeout
+
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        tasks = [
+            fetch_node_batch(session, node, app_name)
+            for node in zconfig.NODES.values()
+        ]
+
+        # Wait for all responses concurrently
+        responses = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # Find the highest indexed batch record
+        for batch_record in responses:
+            if not isinstance(batch_record, dict):  # Skip exceptions
+                continue
+            if batch_record.get("index", 0) > last_finalized_batch_record.get("index", 0):
+                last_finalized_batch_record = batch_record
+
+    return last_finalized_batch_record
+
+
+def find_highest_finalized_batch_record(app_name: str) -> Dict[str, Any]:
+    """Synchronous wrapper for the async function."""
+    return asyncio.run(async_find_highest_finalized_batch_record(app_name))

--- a/node/node_queries_task.py
+++ b/node/node_queries_task.py
@@ -7,7 +7,7 @@ from config import zconfig
 from common.db import zdb
 
 
-async def fetch_node_last_finalized_batch(
+async def fetch_node_last_finalized_batch_record_or_empty(
         session: aiohttp.ClientSession,
         node: Dict[str, Any],
         app_name: str
@@ -55,7 +55,7 @@ async def _find_all_nodes_last_finalized_batch_record_core(app_name: str) -> Dic
         # Query all nodes concurrently
         async with aiohttp.ClientSession() as session:
             tasks = [
-                fetch_node_last_finalized_batch(session, node, app_name)
+                fetch_node_last_finalized_batch_record_or_empty(session, node, app_name)
                 for node in nodes_to_query
             ]
             results = await asyncio.gather(*tasks)

--- a/node/node_queries_task.py
+++ b/node/node_queries_task.py
@@ -1,78 +1,111 @@
 import asyncio
-from typing import Any, Dict, List
-
+from typing import Any, Dict
 import aiohttp
-
 from common.batch import stateful_batch_to_batch_record
-from common.db import zdb
 from common.logger import zlogger
 from config import zconfig
+from common.db import zdb
 
 
-async def fetch_node_last_finalized_batch(session: aiohttp.ClientSession,
-                                          node: Dict[str, Any],
-                                          app_name: str) -> Dict[str, Any]:
+async def fetch_node_last_finalized_batch(
+        session: aiohttp.ClientSession,
+        node: Dict[str, Any],
+        app_name: str
+) -> Dict[str, Any]:
     """Fetch last finalized batch from a single node asynchronously."""
     url = f'{node["socket"]}/node/{app_name}/batches/finalized/last'
     try:
-        async with session.get(url, headers=zconfig.HEADERS, timeout=aiohttp.ClientTimeout(total=10)) as response:
+        async with session.get(
+                url,
+                headers=zconfig.HEADERS,
+                timeout=aiohttp.ClientTimeout(total=10)
+        ) as response:
+            if response.status != 200:
+                return {}
+
             data = await response.json()
             if data.get("status") == "error":
                 return {}
+
             return stateful_batch_to_batch_record(data["data"])
     except Exception as e:
-        return {"error": f"Node {node['id']} failed: {str(e)}"}
-
-
-async def fetch_all_nodes(app_name: str, nodes_to_query: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Fetch finalized batch records from all nodes asynchronously."""
-    if not nodes_to_query:
-        return []
-
-    async with aiohttp.ClientSession() as session:
-        tasks = [fetch_node_last_finalized_batch(session, node, app_name) for node in nodes_to_query]
-        return await asyncio.gather(*tasks)
+        zlogger.warning(f"Failed to fetch from node {node['id']}: {str(e)}")
+        return {}
 
 
 async def find_highest_finalized_batch_record_async(app_name: str) -> Dict[str, Any]:
-    """Asynchronous version of find_highest_finalized_batch_record."""
-    last_finalized_batch_record = zdb.get_last_operational_batch_record_or_empty(
-        app_name=app_name, state="finalized"
-    )
+    """Core async implementation to find highest finalized batch record."""
+    try:
+        # Get local record first
+        highest_record = zdb.get_last_operational_batch_record_or_empty(
+            app_name=app_name,
+            state="finalized"
+        )
+        highest_index = highest_record.get("index", 0)
 
-    nodes_to_query = [node for node in zconfig.NODES.values() if node["id"] != zconfig.NODE["id"]]
+        # Filter nodes to exclude self
+        nodes_to_query = [
+            node for node in zconfig.NODES.values()
+            if node["id"] != zconfig.NODE["id"]
+        ]
 
-    if not nodes_to_query:
-        return last_finalized_batch_record
+        if not nodes_to_query:
+            return highest_record
 
-    results = await fetch_all_nodes(app_name, nodes_to_query)
+        # Query all nodes concurrently
+        async with aiohttp.ClientSession() as session:
+            tasks = [
+                fetch_node_last_finalized_batch(session, node, app_name)
+                for node in nodes_to_query
+            ]
+            results = await asyncio.gather(*tasks)
 
-    # Log errors if any
-    errors = [res["error"] for res in results if isinstance(res, dict) and "error" in res]
-    if errors:
-        zlogger.error("Errors occurred during node queries:\n" + "\n".join(errors))
+            # Find highest index among valid results
+            for record in results:
+                if not record:  # Skip empty or error results
+                    continue
 
-    # Find highest finalized batch record
-    for batch_record in results:
-        if isinstance(batch_record, dict) and "index" in batch_record:
-            if batch_record.get("index", 0) > last_finalized_batch_record.get("index", 0):
-                last_finalized_batch_record = batch_record
+                record_index = record.get("index", 0)
+                if record_index > highest_index:
+                    highest_index = record_index
+                    highest_record = record
 
-    return last_finalized_batch_record
+        return highest_record
+
+    except Exception as e:
+        zlogger.error(f"Error in find_highest_finalized_batch_record: {str(e)}")
+        # Return local record as fallback
+        return zdb.get_last_operational_batch_record_or_empty(
+            app_name=app_name,
+            state="finalized"
+        )
 
 
 def find_highest_finalized_batch_record(app_name: str) -> Dict[str, Any]:
     """
-    Find the last finalized batch record from all nodes.
-    This function can be called from either synchronous or asynchronous contexts.
+    Thread-safe wrapper to find the highest finalized batch record.
+    Can be called from both sync and async contexts.
     """
     try:
-        # Check if we're already in an event loop
-        loop = asyncio.get_running_loop()
-        # If we are, create a task and ensure it's properly awaited
-        return asyncio.run_coroutine_threadsafe(
-            find_highest_finalized_batch_record_async(app_name), loop
-        ).result()
+        # Try to get the current event loop
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            # We're in an async context (like send_dispute_requests)
+            # We need to create a new loop in this case
+            new_loop = asyncio.new_event_loop()
+            try:
+                return new_loop.run_until_complete(find_highest_finalized_batch_record_async(app_name))
+            finally:
+                new_loop.close()
+        else:
+            # We have a loop but it's not running
+            return loop.run_until_complete(find_highest_finalized_batch_record_async(app_name))
     except RuntimeError:
-        # No running event loop, safe to use run_until_complete
-        return asyncio.run(find_highest_finalized_batch_record_async(app_name))
+        # No event loop exists (like in run_switch_sequencer thread)
+        # Create a new loop for this thread
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            return loop.run_until_complete(find_highest_finalized_batch_record_async(app_name))
+        finally:
+            loop.close()

--- a/node/node_queries_task.py
+++ b/node/node_queries_task.py
@@ -88,29 +88,21 @@ async def _find_all_nodes_last_finalized_batch_record_core(app_name: str) -> Bat
     if not nodes_to_query:
         return highest_record
 
-    try:
         # Query all nodes concurrently
-        async with aiohttp.ClientSession() as session:
-            tasks = [
-                _fetch_node_last_finalized_batch_record_or_empty(session, node, app_name)
-                for node in nodes_to_query
-            ]
-            results = await asyncio.gather(*tasks)
+    async with aiohttp.ClientSession() as session:
+        tasks = [
+            _fetch_node_last_finalized_batch_record_or_empty(session, node, app_name)
+            for node in nodes_to_query
+        ]
+        results = await asyncio.gather(*tasks)
 
-            # Process results and find last finalized index
-            for record in results:
-                if not record:  # Skip empty or error results
-                    continue
-                record_index = record.get("index", 0)
-                if record_index > highest_index:
-                    highest_index = record_index
-                    highest_record = record
+        # Process results and find last finalized index
+        for record in results:
+            if not record:  # Skip empty or error results
+                continue
+            record_index = record.get("index", 0)
+            if record_index > highest_index:
+                highest_index = record_index
+                highest_record = record
 
-        return highest_record
-
-    except aiohttp.ClientError as e:
-        zlogger.error(f"Network error in batch record fetch: {str(e)}")
-        return highest_record
-    except Exception as e:
-        zlogger.error(f"Unexpected error in batch record fetch: {str(e)}")
-        return highest_record
+    return highest_record

--- a/node/routes.py
+++ b/node/routes.py
@@ -171,6 +171,21 @@ def get_last_finalized_batch(app_name: str) -> Response:
     )
 
 
+@node_blueprint.route("/batches/finalized/last", methods=["POST"])
+@utils.validate_version
+def get_last_finalized_batches_in_bulk_mode() -> Response:
+    """Get the last finalized batch record for a given app."""
+    apps = request.get_json()
+    valid_apps = [app_name for app_name in apps if app_name in set(zconfig.APPS)]
+    last_finalized_batch_records = {
+        app_name: batch_record_to_stateful_batch(zdb.get_last_operational_batch_record_or_empty(app_name, "finalized"))
+        for app_name in valid_apps
+    }
+    return success_response(
+        data=last_finalized_batch_records
+    )
+
+
 @node_blueprint.route("/<string:app_name>/batches/<string:state>", methods=["GET"])
 @utils.validate_version
 def get_batches(app_name: str, state: str) -> Response:

--- a/node/routes.py
+++ b/node/routes.py
@@ -171,15 +171,13 @@ def get_last_finalized_batch(app_name: str) -> Response:
     )
 
 
-@node_blueprint.route("/batches/finalized/last", methods=["POST"])
+@node_blueprint.route("/batches/finalized/last", methods=["GET"])
 @utils.validate_version
 def get_last_finalized_batches_in_bulk_mode() -> Response:
-    """Get the last finalized batch record for a given app."""
-    apps = request.get_json()
-    valid_apps = [app_name for app_name in apps if app_name in set(zconfig.APPS)]
+    """Get the last finalized batch record for all apps."""
     last_finalized_batch_records = {
         app_name: batch_record_to_stateful_batch(zdb.get_last_operational_batch_record_or_empty(app_name, "finalized"))
-        for app_name in valid_apps
+        for app_name in zconfig.APPS
     }
     return success_response(
         data=last_finalized_batch_records

--- a/node/routes.py
+++ b/node/routes.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from flask import Blueprint, Response, request
 
+from node import switch
 from common import utils
 from common.batch import batch_record_to_stateful_batch
 from common.db import zdb
@@ -120,7 +121,7 @@ def post_switch_sequencer() -> Response:
     old_sequencer_id, new_sequencer_id = utils.get_switch_parameter_from_proofs(proofs)
 
     def run_switch_sequencer():
-        tasks.switch_sequencer(old_sequencer_id, new_sequencer_id)
+        switch.switch_sequencer(old_sequencer_id, new_sequencer_id)
 
     zlogger.info(f"switch request received {zconfig.NODES[old_sequencer_id]['socket']} -> {zconfig.NODES[new_sequencer_id]['socket']}.")
     threading.Thread(target=run_switch_sequencer).start()

--- a/node/switch.py
+++ b/node/switch.py
@@ -60,6 +60,7 @@ async def _switch_sequencer_core(old_sequencer_id: str, new_sequencer_id: str):
     Used by both sync and async switch functions.
     """
     if old_sequencer_id != zconfig.SEQUENCER["id"]:
+        zlogger.warning(f"Sequencer switch rejected: old_sequencer_id {old_sequencer_id} does not match current sequencer {zconfig.SEQUENCER['id']}")
         return
 
     async with switch_lock:

--- a/node/switch.py
+++ b/node/switch.py
@@ -130,7 +130,7 @@ async def _find_all_nodes_last_finalized_batch_records_core() -> dict[str, Batch
     apps = list(zconfig.APPS.keys())
 
     # Get local records first
-    local_records = {
+    highest_records = {
         app_name: zdb.get_last_operational_batch_record_or_empty(
             app_name=app_name,
             state="finalized"
@@ -138,10 +138,9 @@ async def _find_all_nodes_last_finalized_batch_records_core() -> dict[str, Batch
         for app_name in apps
     }
 
-    highest_records = local_records
     highest_indices = {
         app_name: record.get("index", 0)
-        for app_name, record in local_records.items()
+        for app_name, record in highest_records.items()
     }
 
     # Filter nodes to exclude self

--- a/node/switch.py
+++ b/node/switch.py
@@ -89,9 +89,8 @@ async def _fetch_node_last_finalized_batch_records_or_empty(
     """Fetch last finalized batches for all apps from a single node asynchronously."""
     url = f'{node["socket"]}/node/batches/finalized/last'
     try:
-        async with session.post(
+        async with session.get(
                 url,
-                json=apps,
                 headers=zconfig.HEADERS,
                 timeout=aiohttp.ClientTimeout(total=10)
         ) as response:

--- a/node/switch.py
+++ b/node/switch.py
@@ -159,14 +159,14 @@ async def _find_all_nodes_last_finalized_batch_records_core() -> dict[str, Batch
         ]
         results = await asyncio.gather(*tasks)
 
-        # Process results and find last finalized index for each app
-        for node_records in results:
-            if not node_records:  # Skip empty or error results
-                continue
-            for app_name, record in node_records.items():
-                record_index = record.get("index", 0)
-                if record_index > highest_indices[app_name]:
-                    highest_indices[app_name] = record_index
-                    highest_records[app_name] = record
+    # Process results and find last finalized index for each app
+    for node_records in results:
+        if not node_records:  # Skip empty or error results
+            continue
+        for app_name, record in node_records.items():
+            record_index = record.get("index", 0)
+            if record_index > highest_indices[app_name]:
+                highest_indices[app_name] = record_index
+                highest_records[app_name] = record
 
     return highest_records

--- a/node/switch.py
+++ b/node/switch.py
@@ -26,8 +26,8 @@ async def send_switch_request(session, node, proofs):
     try:
         async with session.post(url, data=data, headers=zconfig.HEADERS) as response:
             await response.text()  # Consume the response
-    except Exception as error:
-        zlogger.error(f"Error occurred while sending switch request to {node['id']}")
+    except Exception as e:
+        zlogger.error(f"Error occurred while sending switch request to {node['id']}: : {str(e)}")
 
 
 async def send_switch_requests(proofs: list[dict[str, Any]]) -> None:

--- a/node/switch.py
+++ b/node/switch.py
@@ -14,7 +14,7 @@ from config import zconfig
 switch_lock: asyncio.Lock = asyncio.Lock()
 
 
-async def send_switch_request(session, node, proofs):
+async def _send_switch_request(session, node, proofs):
     """Send a single switch request to a node."""
     data = json.dumps({
         "proofs": proofs,
@@ -34,7 +34,7 @@ async def send_switch_requests(proofs: list[dict[str, Any]]) -> None:
     zlogger.warning("sending switch requests...")
     async with aiohttp.ClientSession() as session:
         tasks = [
-            send_switch_request(session, node, proofs)
+            _send_switch_request(session, node, proofs)
             for node in zconfig.NODES.values() if node["id"] != zconfig.NODE["id"]
         ]
         await asyncio.gather(*tasks)

--- a/node/switch.py
+++ b/node/switch.py
@@ -91,7 +91,7 @@ async def _fetch_node_last_finalized_batch_records_or_empty(
         return {}
 
 
-async def find_all_nodes_last_finalized_batch_records_async() -> dict[str, BatchRecord]:
+async def find_all_nodes_last_finalized_batch_records_async_with_fallback() -> dict[str, BatchRecord]:
     """
     Async wrapper to find the last finalized batch records of network for all apps.
     Can be called from async contexts.
@@ -173,7 +173,7 @@ async def _switch_sequencer_core(old_sequencer_id: str, new_sequencer_id: str):
     try:
         zconfig.update_sequencer(new_sequencer_id)
 
-        all_nodes_last_finalized_batch_records = await find_all_nodes_last_finalized_batch_records_async()
+        all_nodes_last_finalized_batch_records = await find_all_nodes_last_finalized_batch_records_async_with_fallback()
 
         for app_name, batch_record in all_nodes_last_finalized_batch_records.items():
             if batch_record:

--- a/node/switch.py
+++ b/node/switch.py
@@ -26,7 +26,7 @@ async def send_switch_request(session, node, proofs):
         async with session.post(url, data=data, headers=zconfig.HEADERS) as response:
             await response.text()  # Consume the response
     except Exception as e:
-        zlogger.error(f"Error occurred while sending switch request to {node['id']}: {str(e)}")
+        zlogger.warning(f"Error occurred while sending switch request to {node['id']}: {e}")
 
 
 async def send_switch_requests(proofs: list[dict[str, Any]]) -> None:
@@ -60,7 +60,8 @@ async def _switch_sequencer_core(old_sequencer_id: str, new_sequencer_id: str):
     Used by both sync and async switch functions.
     """
     if old_sequencer_id != zconfig.SEQUENCER["id"]:
-        zlogger.warning(f"Sequencer switch rejected: old_sequencer_id {old_sequencer_id} does not match current sequencer {zconfig.SEQUENCER['id']}")
+        old_sequencer_node = zconfig.NODES[old_sequencer_id]
+        zlogger.warning(f"Sequencer switch rejected: old sequencer {old_sequencer_node['socket']} does not match current sequencer {zconfig.SEQUENCER['socket']}")
         return
 
     async with switch_lock:
@@ -96,12 +97,12 @@ async def _fetch_node_last_finalized_batch_records_or_empty(
         ) as response:
             if response.status != 200:
                 error_text = await response.text()
-                zlogger.warning(f"Failed to fetch last finalized record from node {node['id']}: {error_text}")
+                zlogger.warning(f"Failed to fetch last finalized record from node {node['socket']}: {error_text}")
                 return {}
 
             data = await response.json()
             if data.get("status") == "error":
-                zlogger.warning(f"Failed to fetch last finalized record from node {node['id']}: {data}")
+                zlogger.warning(f"Failed to fetch last finalized record from node {node['socket']}: {data}")
                 return {}
 
             return {
@@ -109,7 +110,7 @@ async def _fetch_node_last_finalized_batch_records_or_empty(
                 for app_name, batch_data in data["data"].items()
             }
     except Exception as e:
-        zlogger.warning(f"Failed to fetch last finalized record from node {node['id']}: {e}")
+        zlogger.warning(f"Failed to fetch last finalized record from node {node['socket']}: {e}")
         return {}
 
 

--- a/node/switch.py
+++ b/node/switch.py
@@ -95,10 +95,13 @@ async def _fetch_node_last_finalized_batch_records_or_empty(
                 timeout=aiohttp.ClientTimeout(total=10)
         ) as response:
             if response.status != 200:
+                error_text = await response.text()
+                zlogger.warning(f"Failed to fetch last finalized record from node {node['id']}: {error_text}")
                 return {}
 
             data = await response.json()
             if data.get("status") == "error":
+                zlogger.warning(f"Failed to fetch last finalized record from node {node['id']}: {data}")
                 return {}
 
             return {
@@ -106,7 +109,7 @@ async def _fetch_node_last_finalized_batch_records_or_empty(
                 for app_name, batch_data in data["data"].items()
             }
     except Exception as e:
-        zlogger.warning(f"Failed to fetch from node {node['id']}: {str(e)}")
+        zlogger.warning(f"Failed to fetch last finalized record from node {node['id']}: {e}")
         return {}
 
 

--- a/node/switch.py
+++ b/node/switch.py
@@ -40,10 +40,6 @@ async def send_switch_requests(proofs: list[dict[str, Any]]) -> None:
         await asyncio.gather(*tasks)
 
 
-def verify_switch_sequencer(old_sequencer_id: str) -> bool:
-    return old_sequencer_id == zconfig.SEQUENCER["id"]
-
-
 def switch_sequencer(old_sequencer_id: str, new_sequencer_id: str):
     """
     Synchronous wrapper for sequencer switching.
@@ -63,7 +59,7 @@ async def _switch_sequencer_core(old_sequencer_id: str, new_sequencer_id: str):
     Core implementation of sequencer switching logic.
     Used by both sync and async switch functions.
     """
-    if not verify_switch_sequencer(old_sequencer_id):
+    if old_sequencer_id != zconfig.SEQUENCER["id"]:
         return
 
     async with switch_lock:

--- a/node/switch.py
+++ b/node/switch.py
@@ -136,7 +136,7 @@ async def _find_all_nodes_last_finalized_batch_records_core() -> dict[str, Batch
         for app_name in apps
     }
 
-    highest_records = local_records.copy()
+    highest_records = local_records
     highest_indices = {
         app_name: record.get("index", 0)
         for app_name, record in local_records.items()

--- a/node/switch.py
+++ b/node/switch.py
@@ -116,19 +116,7 @@ async def _fetch_node_last_finalized_batch_records_or_empty(
 
 
 async def get_network_last_finalized_batch_records() -> dict[str, BatchRecord]:
-    """
-    Retrieves the last finalized batch records from all network nodes.
-    Can be called from async contexts.
-    """
-    try:
-        return await _find_all_nodes_last_finalized_batch_records_core()
-    except Exception as e:
-        zlogger.error(f"Critical error while fetching network finalized batch records: {str(e)}")
-        raise
-
-
-async def _find_all_nodes_last_finalized_batch_records_core() -> dict[str, BatchRecord]:
-    """Core async implementation to find all nodes last finalized batch records for all apps."""
+    """Retrieves the last finalized batch records from all network nodes."""
     apps = list(zconfig.APPS.keys())
 
     # Get local records first

--- a/node/switch.py
+++ b/node/switch.py
@@ -100,7 +100,7 @@ async def find_all_nodes_last_finalized_batch_records_async_with_fallback() -> d
         # Get the result asynchronously
         return await _find_all_nodes_last_finalized_batch_records_core()
     except Exception as e:
-        zlogger.error(f"Critical error in find_all_nodes_last_finalized_batch_records: {str(e)}")
+        zlogger.error(f"Critical error while fetching network finalized batch records: {str(e)}")
         # Return local records as ultimate fallback
         return {
             app_name: zdb.get_last_operational_batch_record_or_empty(

--- a/node/switch.py
+++ b/node/switch.py
@@ -106,8 +106,9 @@ async def _fetch_node_last_finalized_batch_records_or_empty(
                 return {}
 
             return {
-                app_name: stateful_batch_to_batch_record(batch_data)
-                for app_name, batch_data in data["data"].items()
+                app_name: stateful_batch_to_batch_record(data["data"][app_name])
+                for app_name in zconfig.APPS
+                if app_name in data["data"]
             }
     except Exception as e:
         zlogger.warning(f"Failed to fetch last finalized record from node {node['socket']}: {e}")

--- a/node/switch.py
+++ b/node/switch.py
@@ -83,8 +83,7 @@ async def _switch_sequencer_core(old_sequencer_id: str, new_sequencer_id: str):
 
 async def _fetch_node_last_finalized_batch_records_or_empty(
         session: aiohttp.ClientSession,
-        node: dict[str, Any],
-        apps: list[str]
+        node: dict[str, Any]
 ) -> dict[str, BatchRecord]:
     """Fetch last finalized batches for all apps from a single node asynchronously."""
     url = f'{node["socket"]}/node/batches/finalized/last'
@@ -153,7 +152,7 @@ async def _find_all_nodes_last_finalized_batch_records_core() -> dict[str, Batch
     # Query all nodes concurrently
     async with aiohttp.ClientSession() as session:
         tasks = [
-            _fetch_node_last_finalized_batch_records_or_empty(session, node, apps)
+            _fetch_node_last_finalized_batch_records_or_empty(session, node)
             for node in nodes_to_query
         ]
         results = await asyncio.gather(*tasks)

--- a/node/tasks.py
+++ b/node/tasks.py
@@ -22,7 +22,7 @@ from node.rate_limit import try_acquire_rate_limit_of_self_node
 from common.logger import zlogger
 from config import zconfig
 from node.rate_limit import get_remaining_capacity_kb_of_self_node
-from node.node_queries_task import find_highest_finalized_batch_record, find_highest_finalized_batch_record_async
+from node.node_queries_task import find_all_nodes_last_finalized_batch_record, find_all_nodes_last_finalized_batch_record_async
 
 switch_lock: threading.Lock = threading.Lock()
 
@@ -424,9 +424,9 @@ def switch_sequencer(old_sequencer_id: str, new_sequencer_id: str):
         zconfig.update_sequencer(new_sequencer_id)
 
         for app_name in list(zconfig.APPS.keys()):
-            highest_finalized_batch_record = find_highest_finalized_batch_record(app_name)
-            if highest_finalized_batch_record:
-                zdb.reinitialize(app_name, new_sequencer_id, highest_finalized_batch_record)
+            all_nodes_last_finalized_batch_record = find_all_nodes_last_finalized_batch_record(app_name)
+            if all_nodes_last_finalized_batch_record:
+                zdb.reinitialize(app_name, new_sequencer_id, all_nodes_last_finalized_batch_record)
             zdb.reset_not_finalized_batches_timestamps(app_name)
 
         if zconfig.NODE['id'] != zconfig.SEQUENCER['id']:
@@ -465,7 +465,7 @@ async def switch_sequencer_async(old_sequencer_id: str, new_sequencer_id: str):
 
 async def process_app(app_name: str, new_sequencer_id: str):
     """Helper function to handle the app processing concurrently."""
-    highest_finalized_batch_record = await find_highest_finalized_batch_record_async(app_name)  # Now await the async function
-    if highest_finalized_batch_record:
-        zdb.reinitialize(app_name, new_sequencer_id, highest_finalized_batch_record)
+    all_nodes_last_finalized_batch_record = await find_all_nodes_last_finalized_batch_record_async(app_name)  # Now await the async function
+    if all_nodes_last_finalized_batch_record:
+        zdb.reinitialize(app_name, new_sequencer_id, all_nodes_last_finalized_batch_record)
     zdb.reset_not_finalized_batches_timestamps(app_name)

--- a/node/tasks.py
+++ b/node/tasks.py
@@ -5,25 +5,24 @@ dispute handling, and switching sequencers.
 
 import asyncio
 import json
+import random
 import threading
 import time
 from typing import Any
 from typing import List
-import random
+
 import aiohttp
 import requests
 from eigensdk.crypto.bls import attestation
 
 from common import bls, utils
-from common.batch import BatchRecord, stateful_batch_to_batch_record
 from common.db import zdb
 from common.errors import ErrorCodes, ErrorMessages
-from node.rate_limit import try_acquire_rate_limit_of_self_node
 from common.logger import zlogger
 from config import zconfig
+from node.node_queries_task import find_all_nodes_last_finalized_batch_record_async
 from node.rate_limit import get_remaining_capacity_kb_of_self_node
-from node.node_queries_task import find_all_nodes_last_finalized_batch_record, \
-    find_all_nodes_last_finalized_batch_record_async
+from node.rate_limit import try_acquire_rate_limit_of_self_node
 
 switch_lock: threading.Lock = threading.Lock()
 


### PR DESCRIPTION
- Making the process of querying all nodes in the network to find the highest finalized batches before switching to the new sequencer, concurrent to ensure faster switch process