### PR TITLE
Fix getting snapshotted finalized batches in response to putting batches when the node is too far behind the sequencer.

### DIFF
--- a/common/db.py
+++ b/common/db.py
@@ -243,7 +243,7 @@ class InMemoryDB:
             / zconfig.SNAPSHOT_CHUNK
         )
 
-        if current_chunk != finalized_chunk:
+        if current_chunk < finalized_chunk:
             loaded_finalized_batches = self._load_finalized_batch_sequence(
                 app_name, after + 1
             )
@@ -254,10 +254,11 @@ class InMemoryDB:
                 batch_hash_set,
             )
 
-        if len(batch_sequence) < zconfig.API_BATCHES_LIMIT and next_chunk not in [
-            current_chunk,
-            finalized_chunk,
-        ]:
+        if (
+            next_chunk != current_chunk
+            and len(batch_sequence) < zconfig.API_BATCHES_LIMIT
+            and next_chunk < finalized_chunk
+        ):
             loaded_finalized_batches = self._load_finalized_batch_sequence(
                 app_name, after + 1 + len(batch_sequence)
             )


### PR DESCRIPTION
When nodes send new batches to the sequencer, it responds with the sequenced, locked, and finalized batches that follow the node’s last sequenced batch index. For this purpose, the sequencer calls the `InMemoryDB.get_global_operational_batch_sequence` method. In this method, if the node is too far behind the sequencer, it must search for finalized batches that have persisted in file storage (since not all batches can be held in memory). The following code implements this logic:

https://github.com/zellular-xyz/zsequencer/blob/e75b002ae413c4474a761a07cf6c122b7ce4e96f/common/db.py#L225-L272

However, the code has a bug: it only searches files when the state is `None` or `finalized`, based on the previous implementation that took a set of states or `None`. In the new implementation, the state is no longer optional, and we also need to return finalized batches when calling the function with the `"sequenced"` state (because all finalized batches are also sequenced).

In this PR, the condition is removed entirely, as finalized states are both locked and sequenced and we currently only support inclusive queries.