### PR TITLE
Fix: Persist Synced Status After Initial Sync

### DIFF
--- a/config.py
+++ b/config.py
@@ -91,9 +91,6 @@ class Config:
     def set_synced_flag(self):
         self._SYNCED_FLAG = True
 
-    def unset_synced_flag(self):
-        self._SYNCED_FLAG = False
-
     def get_mode(self):
         return self._MODE
 

--- a/node/tasks.py
+++ b/node/tasks.py
@@ -37,7 +37,6 @@ def send_batches() -> None:
             continue
 
         single_iteration_apps_sync = False
-        zconfig.unset_synced_flag()
 
         while True:
             finish_condition = send_app_batches_iteration(app_name=app_name)


### PR DESCRIPTION
This change ensures a node retains its `synced` flag after the initial synchronization with the sequencer.

If nodes unset the `synced` flag when falling behind, a malicious sequencer could prevent them from participating in disputes. This change avoids that vulnerability by making the `synced` status permanent once set.