### PR TITLE
Improve dispute management

### DIFF
--- a/common/api_models.py
+++ b/common/api_models.py
@@ -130,7 +130,6 @@ class SwitchProof(BaseModel):
 class SwitchRequest(BaseModel):
     """Request to switch sequencers with supporting proofs."""
 
-    timestamp: int
     proofs: list[SwitchProof]
 
 

--- a/common/errors.py
+++ b/common/errors.py
@@ -61,6 +61,12 @@ class IssueNotFoundError(BaseHTTPError):
     log_level = logging.INFO
 
 
+class InvalidTimestampError(BaseHTTPError):
+    status_code = status.HTTP_400_BAD_REQUEST
+    message = "Requested timestamp does not match the node timestamp."
+    log_level = logging.INFO
+
+
 class SequencerChangeNotApprovedError(BaseHTTPError):
     status_code = status.HTTP_403_FORBIDDEN
     message = "The sequencer change request is not approved."

--- a/node/routers.py
+++ b/node/routers.py
@@ -165,7 +165,7 @@ async def post_dispute(request: DisputeRequest) -> DisputeResponse:
         or zdb.is_sequencer_down
     ):
         now = int(time.time())
-        if not now - 5 <= request.timestamp <= now + 5:
+        if not (now - 5 <= request.timestamp <= now + 5):
             raise InvalidTimestampError()
 
         signature = utils.eth_sign(f"{zconfig.SEQUENCER['id']}{request.timestamp}")

--- a/node/routers.py
+++ b/node/routers.py
@@ -33,6 +33,7 @@ from common.errors import (
     BatchSizeExceededError,
     InvalidRequestError,
     InvalidSequencerError,
+    InvalidTimestampError,
     IsNotPostingNodeError,
     IsSequencerError,
     IssueNotFoundError,
@@ -163,14 +164,17 @@ async def post_dispute(request: DisputeRequest) -> DisputeResponse:
         or zdb.has_delayed_batches()
         or zdb.is_sequencer_down
     ):
-        timestamp = int(time.time())
-        signature = utils.eth_sign(f"{zconfig.SEQUENCER['id']}{timestamp}")
+        now = int(time.time())
+        if not now - 5 <= request.timestamp <= now + 5:
+            raise InvalidTimestampError()
+
+        signature = utils.eth_sign(f"{zconfig.SEQUENCER['id']}{request.timestamp}")
 
         response_data = DisputeData(
             node_id=zconfig.NODE["id"],
             old_sequencer_id=zconfig.SEQUENCER["id"],
             new_sequencer_id=switch.get_next_sequencer_id(zconfig.SEQUENCER["id"]),
-            timestamp=timestamp,
+            timestamp=request.timestamp,
             signature=signature,
         )
 

--- a/node/switch.py
+++ b/node/switch.py
@@ -14,7 +14,7 @@ from aiohttp.client_exceptions import ClientError
 from aiohttp.web import HTTPError
 
 from common import utils
-from common.api_models import SwitchProof
+from common.api_models import SwitchProof, SwitchRequest
 from common.batch import BatchRecord, stateful_batch_to_batch_record
 from common.batch_sequence import BatchSequence
 from common.bls import is_sync_point_signature_verified
@@ -167,7 +167,7 @@ async def _send_switch_request(session, node, proofs: list[SwitchProof]):
 
     try:
         async with session.post(
-            url, json={"proofs": [proof.dict() for proof in proofs]}
+            url, json=SwitchRequest(proofs=proofs).model_dump()
         ) as response:
             await response.text()
     except (HTTPError, ClientError, asyncio.TimeoutError) as e:

--- a/node/switch.py
+++ b/node/switch.py
@@ -79,7 +79,7 @@ async def gather_disputes() -> tuple[list[SwitchProof], float]:
         asyncio.create_task(send_dispute_request(node, zdb.is_sequencer_down)): node[
             "id"
         ]
-        for node in list(zconfig.NODES.values())
+        for node in list(zconfig.last_state.attesting_nodes.values())
         if node["id"] != zconfig.NODE["id"]
     }
 

--- a/node/switch.py
+++ b/node/switch.py
@@ -163,28 +163,12 @@ async def send_dispute_requests() -> None:
 
 async def _send_switch_request(session, node, proofs: list[SwitchProof]):
     """Send a single switch request to a node."""
-    # Convert SwitchProof objects to dictionaries for JSON serialization
-    proofs_dict = [
-        {
-            "node_id": proof.node_id,
-            "old_sequencer_id": proof.old_sequencer_id,
-            "new_sequencer_id": proof.new_sequencer_id,
-            "timestamp": proof.timestamp,
-            "signature": proof.signature,
-        }
-        for proof in proofs
-    ]
-
-    data = json.dumps(
-        {
-            "proofs": proofs_dict,
-            "timestamp": int(time.time()),
-        }
-    )
     url = f"{node['socket']}/node/switch"
 
     try:
-        async with session.post(url, data=data) as response:
+        async with session.post(
+            url, json={"proofs": [proof.dict() for proof in proofs]}
+        ) as response:
             await response.text()
     except (HTTPError, ClientError, asyncio.TimeoutError) as e:
         zlogger.warning(


### PR DESCRIPTION
- Removes redundant timestamp from switch requests
- Updates dispute route to sign requested timestamp instead of the node timestamp to enable aggregation in the future
- Limits dispute querying to attesting nodes