### PR TITLE
More Inclusive Dispute Approvement

### DIFF
--- a/common/errors.py
+++ b/common/errors.py
@@ -49,12 +49,6 @@ class NotSyncedError(BaseHTTPError):
     log_level = logging.WARNING
 
 
-class InvalidSequencerError(BaseHTTPError):
-    status_code = status.HTTP_400_BAD_REQUEST
-    message = "The sequencer ID is invalid."
-    log_level = logging.INFO
-
-
 class IssueNotFoundError(BaseHTTPError):
     status_code = status.HTTP_404_NOT_FOUND
     message = "The specified issue was not found."

--- a/common/errors.py
+++ b/common/errors.py
@@ -49,6 +49,12 @@ class NotSyncedError(BaseHTTPError):
     log_level = logging.WARNING
 
 
+class InvalidSequencerError(BaseHTTPError):
+    status_code = status.HTTP_400_BAD_REQUEST
+    message = "The sequencer ID is invalid."
+    log_level = logging.INFO
+
+
 class IssueNotFoundError(BaseHTTPError):
     status_code = status.HTTP_404_NOT_FOUND
     message = "The specified issue was not found."

--- a/common/utils.py
+++ b/common/utils.py
@@ -49,7 +49,7 @@ def validate_version(role: str) -> Callable[[Request], None]:
 
 def is_synced(request: Request) -> None:
     """Decorator to ensure the app is synced with sequencer (leader) before processing the request."""
-    if not zconfig.get_synced_flag():
+    if not zconfig.is_sequencer and not zconfig.get_synced_flag():
         raise NotSyncedError()
 
 

--- a/docs/source/protocol.rst
+++ b/docs/source/protocol.rst
@@ -44,7 +44,7 @@ Finalising
 
 * **Store Latest Index:** The sequencer keeps track of the latest index returned to each node after a post request.
 
-* **Determine Syncing Point:** The sequencer periodically calculates the syncing point, the index reached by a threshold number of nodes, and requests a signature from them on the chaining hash of that index to indicate readiness to lock transactions.
+* **Determine Syncing Point:** The sequencer periodically calculates the syncing point, the index reached by more than 2/3 of nodes, and requests a signature from them on the chaining hash of that index to indicate readiness to lock transactions.
 
 * **Aggregate Locking Signatures:** Upon receiving locking signatures from the nodes, the sequencer aggregates them and sends the aggregated locking signature back to the nodes. Nodes verify and update the state of all transactions up to that index to *locked* and respond with a finalising signature.
 
@@ -70,7 +70,7 @@ Disputing
 
 * **Sharing Evidence:** The node shares the problematic transactions with other nodes and collects their signatures to confirm the Sequencer's malfunction.
 
-* **Triggering a Switch:** If the threshold number of nodes confirms the issue, the node sends the collected signatures to all nodes to initiate the switching process.
+* **Triggering a Switch:** If more than 1/3 of nodes confirms the issue, the node sends the collected signatures to all nodes to initiate the switching process.
 
 Switching
 ~~~~~~~~~

--- a/node/routers.py
+++ b/node/routers.py
@@ -148,7 +148,6 @@ async def post_sign_sync_point(request: SignSyncPointRequest) -> SignSyncPointRe
     "/dispute",
     dependencies=[
         Depends(utils.validate_version("node")),
-        Depends(utils.not_sequencer),
         Depends(utils.is_synced),
         Depends(auth.verify_node_access),
     ],

--- a/node/switch.py
+++ b/node/switch.py
@@ -271,7 +271,7 @@ async def _sync_with_latest_locks() -> None:
                 chaining_hash=last_locked_batch.get("chaining_hash"),
                 tag=last_locked_batch.get("locked_tag"),
                 signature_hex=last_locked_batch.get("lock_signature"),
-                nonsigners=last_locked_batch.get("locked_nonsigners", []),
+                nonsigners=last_locked_batch.get("locked_nonsigners") or [],
             ):
                 zlogger.warning(
                     f"Node id: {node_id} claiming locked signature on index : {last_locked_batch_record.get('index')} is not verified."


### PR DESCRIPTION
This PR updates the dispute logic in **zsequencer**:

- Lowers approval threshold from **2/3 to 1/3** of nodes.
- Allows sequencers to vote in disputes **unless they are the target**.
- Lets nodes approve disputes **if the dispute targets a different sequencer** than their own.
- Resolves a bug where the latency queue was reset **before** the switch waiting period instead of **after**.
- Rejects switch if the disputed sequencer is **not equal** to the node’s current sequencer.

These changes aim to improve responsiveness, fix timing issues, and ensure consistent behavior during sequencer switches.